### PR TITLE
Make yaml indent width configurable

### DIFF
--- a/lib/yaml_includes.py
+++ b/lib/yaml_includes.py
@@ -230,13 +230,13 @@ def read_yaml_from_view(view):
     )
 
 
-def yaml_dumps(obj, default_flow_style=None, strip_tabs=False, detect_timestamp=False):
+def yaml_dumps(obj, default_flow_style=None, indent=4, strip_tabs=False, detect_timestamp=False):
     """Wrapper for yaml dump."""
 
     return yaml_dump(
         yaml_convert_to(obj, strip_tabs, detect_timestamp),
         width=None,
-        indent=4,
+        indent=indent,
         allow_unicode=True,
         default_flow_style=default_flow_style
     )

--- a/serialized_data_converter.py
+++ b/serialized_data_converter.py
@@ -349,6 +349,7 @@ class SerializedPlistToYamlCommand(_LanguageConverter):
                 self.output = yaml.yaml_dumps(
                     self.plist,
                     default_flow_style=default_flow_style,
+                    indent=self.settings.get("yaml_indent"),
                     strip_tabs=self.strip_tabs,
                     detect_timestamp=self.settings.get("yaml_detect_timestamp", True)
                 )
@@ -663,6 +664,7 @@ class SerializedJsonToYamlCommand(_LanguageConverter):
                 self.output = yaml.yaml_dumps(
                     self.json,
                     default_flow_style=default_flow_style,
+                    indent=self.settings.get("yaml_indent"),
                     strip_tabs=self.strip_tabs,
                     detect_timestamp=self.settings.get("yaml_detect_timestamp", True)
                 )

--- a/serialized_data_converter.py
+++ b/serialized_data_converter.py
@@ -349,7 +349,7 @@ class SerializedPlistToYamlCommand(_LanguageConverter):
                 self.output = yaml.yaml_dumps(
                     self.plist,
                     default_flow_style=default_flow_style,
-                    indent=self.settings.get("yaml_indent"),
+                    indent=self.settings.get("yaml_indent", 4),
                     strip_tabs=self.strip_tabs,
                     detect_timestamp=self.settings.get("yaml_detect_timestamp", True)
                 )
@@ -664,7 +664,7 @@ class SerializedJsonToYamlCommand(_LanguageConverter):
                 self.output = yaml.yaml_dumps(
                     self.json,
                     default_flow_style=default_flow_style,
-                    indent=self.settings.get("yaml_indent"),
+                    indent=self.settings.get("yaml_indent", 4),
                     strip_tabs=self.strip_tabs,
                     detect_timestamp=self.settings.get("yaml_detect_timestamp", True)
                 )

--- a/serialized_data_converter.sublime-settings
+++ b/serialized_data_converter.sublime-settings
@@ -73,6 +73,8 @@
         // {"ext": "tmTheme.YAML", "command": "yaml_to_plist"}
     ],
 
+    "yaml_indent": 4,
+
     // These are language extensions in which the converter will strip tabs
     // to ensure multilines aren't quoted with "\t".  It also strips trailing spaces
     // from multi-line strings. This helps multiline strings convert in a pretty format.

--- a/serialized_data_converter.sublime-settings
+++ b/serialized_data_converter.sublime-settings
@@ -73,6 +73,7 @@
         // {"ext": "tmTheme.YAML", "command": "yaml_to_plist"}
     ],
 
+    // Sets the indentation level for generated yaml
     "yaml_indent": 4,
 
     // These are language extensions in which the converter will strip tabs


### PR DESCRIPTION
It still default to 4, but now it's configurable via `yaml_indent`.
